### PR TITLE
Remove asynchronicity from Command interfaces

### DIFF
--- a/concursus-domain-json/src/test/java/com/opencredo/concursus/domain/json/commands/channels/JsonCommandOutChannelTest.java
+++ b/concursus-domain-json/src/test/java/com/opencredo/concursus/domain/json/commands/channels/JsonCommandOutChannelTest.java
@@ -15,8 +15,6 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -25,13 +23,13 @@ public class JsonCommandOutChannelTest {
 
     @HandlesCommandsFor("test")
     public interface TestCommands {
-        CompletableFuture<UUID> create(StreamTimestamp ts, UUID aggregateId, String name);
+        UUID create(StreamTimestamp ts, UUID aggregateId, String name);
     }
 
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
     private final CommandTypeMatcher typeMatcher = CommandInterfaceInfo.forInterface(TestCommands.class).getCommandTypeMatcher();
 
-    private final TestCommands commandProcessor = (ts, id, name) -> CompletableFuture.completedFuture(id);
+    private final TestCommands commandProcessor = (ts, id, name) -> id;
 
     private final CommandBus commandBus = CommandBus.executingWith(
         ProcessingCommandExecutor.processingWith(
@@ -53,11 +51,11 @@ public class JsonCommandOutChannelTest {
     private final TestCommands proxy = proxyFactory.getProxy(TestCommands.class);
 
     @Test
-    public void dispatchViaJsonChannel() throws ExecutionException, InterruptedException {
+    public void dispatchViaJsonChannel() {
         UUID aggregateId = UUID.randomUUID();
 
         assertThat(
-                proxy.create(StreamTimestamp.of("test", Instant.now()), aggregateId, "Arthur Putey").get(),
+                proxy.create(StreamTimestamp.of("test", Instant.now()), aggregateId, "Arthur Putey"),
                 equalTo(aggregateId));
     }
 }

--- a/concursus-domain/src/main/java/com/opencredo/concursus/domain/commands/CommandResult.java
+++ b/concursus-domain/src/main/java/com/opencredo/concursus/domain/commands/CommandResult.java
@@ -24,7 +24,7 @@ public final class CommandResult {
         checkNotNull(resultType, "resultType must not be null");
         checkNotNull(resultValue, "resultValue must not be null");
 
-        if (resultType.equals(Void.class)) {
+        if (resultType.equals(void.class)) {
             checkArgument(!resultValue.isPresent(),
                     "resultValue must be empty if result type is void");
         } else {

--- a/concursus-examples/src/test/java/com/opencredo/concursus/examples/CommandProcessingExample.java
+++ b/concursus-examples/src/test/java/com/opencredo/concursus/examples/CommandProcessingExample.java
@@ -1,9 +1,9 @@
 package com.opencredo.concursus.examples;
 
 import com.opencredo.concursus.domain.commands.dispatching.CommandBus;
-import com.opencredo.concursus.domain.commands.filters.LoggingCommandExecutorFilter;
 import com.opencredo.concursus.domain.commands.dispatching.Slf4jCommandLog;
 import com.opencredo.concursus.domain.commands.dispatching.ThreadpoolCommandExecutor;
+import com.opencredo.concursus.domain.commands.filters.LoggingCommandExecutorFilter;
 import com.opencredo.concursus.domain.events.dispatching.EventBus;
 import com.opencredo.concursus.domain.events.logging.EventLog;
 import com.opencredo.concursus.domain.events.processing.EventBatchProcessor;
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import java.time.LocalDate;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,17 +47,17 @@ public class CommandProcessingExample {
     private final CommandProxyFactory commandProxyFactory = CommandProxyFactory.proxying(commandBus.toCommandOutChannel());
 
     @Test
-    public void issueCommands() throws ExecutionException, InterruptedException {
+    public void issueCommands() {
         Person.Commands personCommands = commandProxyFactory.getProxy(Person.Commands.class);
 
-        Person createdPerson = personCommands.create(StreamTimestamp.now(), UUID.randomUUID(), "Arthur Putey", LocalDate.parse("1968-05-28")).get();
+        Person createdPerson = personCommands.create(StreamTimestamp.now(), UUID.randomUUID(), "Arthur Putey", LocalDate.parse("1968-05-28"));
 
         assertThat(createdPerson.getName(), equalTo("Arthur Putey"));
 
-        Person updatedPerson = personCommands.changeName(StreamTimestamp.now(), createdPerson.getId(), "Arthur Mumby").get();
+        Person updatedPerson = personCommands.changeName(StreamTimestamp.now(), createdPerson.getId(), "Arthur Mumby");
         assertThat(updatedPerson.getName(), equalTo("Arthur Mumby"));
 
-        Person movedPerson = personCommands.moveToAddress(StreamTimestamp.now(), createdPerson.getId(), UUID.randomUUID()).get();
+        Person movedPerson = personCommands.moveToAddress(StreamTimestamp.now(), createdPerson.getId(), UUID.randomUUID());
 
         assertThat(movedPerson.getCurrentAddressId(), not(equalTo(updatedPerson.getCurrentAddressId())));
     }

--- a/concursus-examples/src/test/java/com/opencredo/concursus/examples/Person.java
+++ b/concursus-examples/src/test/java/com/opencredo/concursus/examples/Person.java
@@ -6,17 +6,16 @@ import com.opencredo.concursus.mapping.annotations.*;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @HandlesEventsFor("person")
 public final class Person {
 
     @HandlesCommandsFor("person")
     public interface Commands {
-        CompletableFuture<Person> create(StreamTimestamp ts, UUID personId, String name, LocalDate dob);
-        CompletableFuture<Person> changeName(StreamTimestamp ts, UUID personId, String newName);
-        CompletableFuture<Person> moveToAddress(StreamTimestamp ts, UUID personId, UUID addressId);
-        CompletableFuture<Void> delete(StreamTimestamp ts, UUID personId);
+        Person create(StreamTimestamp ts, UUID personId, String name, LocalDate dob);
+        Person changeName(StreamTimestamp ts, UUID personId, String newName);
+        Person moveToAddress(StreamTimestamp ts, UUID personId, UUID addressId);
+        void delete(StreamTimestamp ts, UUID personId);
     }
 
     @HandlesEventsFor("person")

--- a/concursus-examples/src/test/java/com/opencredo/concursus/examples/SubscribingExample.java
+++ b/concursus-examples/src/test/java/com/opencredo/concursus/examples/SubscribingExample.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 
 import java.time.LocalDate;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 
 import static org.mockito.Matchers.any;
@@ -50,7 +49,7 @@ public class SubscribingExample {
     private final CommandProxyFactory commandProxyFactory = CommandProxyFactory.proxying(commandBus.toCommandOutChannel());
 
     @Test
-    public void eventsAreDispatchedToSubscribersByType() throws ExecutionException, InterruptedException {
+    public void eventsAreDispatchedToSubscribersByType() {
         Person.Events personEventHandler = mock(Person.Events.class);
         Address.Events addressEventHandler = mock(Address.Events.class);
 
@@ -65,9 +64,9 @@ public class SubscribingExample {
         UUID address1Id = UUID.randomUUID();
         UUID address2Id = UUID.randomUUID();
 
-        personCommands.create(StreamTimestamp.now(), personId, "Arthur Daley", LocalDate.parse("1968-05-28")).get();
-        personCommands.moveToAddress(StreamTimestamp.now(), personId, address1Id).get();
-        personCommands.moveToAddress(StreamTimestamp.now(), personId, address2Id).get();
+        personCommands.create(StreamTimestamp.now(), personId, "Arthur Daley", LocalDate.parse("1968-05-28"));
+        personCommands.moveToAddress(StreamTimestamp.now(), personId, address1Id);
+        personCommands.moveToAddress(StreamTimestamp.now(), personId, address2Id);
 
         verify(personEventHandler).created(any(StreamTimestamp.class), eq(personId), eq("Arthur Daley"), any(LocalDate.class));
         verify(personEventHandler).movedToAddress(any(StreamTimestamp.class), eq(personId), eq(address1Id));

--- a/concursus-game-demo/src/main/java/com/opencredo/concursus/demos/game/commands/PlayerCommands.java
+++ b/concursus-game-demo/src/main/java/com/opencredo/concursus/demos/game/commands/PlayerCommands.java
@@ -7,19 +7,18 @@ import com.opencredo.concursus.mapping.annotations.HandlesCommandsFor;
 
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @HandlesCommandsFor("player")
 public interface PlayerCommands {
 
-    CompletableFuture<UUID> create(StreamTimestamp ts, UUID playerId, String playerName);
-    CompletableFuture<UUID> delete(StreamTimestamp ts, UUID playerId);
-    CompletableFuture<Void> changeName(StreamTimestamp ts, UUID playerId, String newPlayerName);
+    UUID create(StreamTimestamp ts, UUID playerId, String playerName);
+    void delete(StreamTimestamp ts, UUID playerId);
+    void changeName(StreamTimestamp ts, UUID playerId, String newPlayerName);
 
-    CompletableFuture<UUID> startGame(StreamTimestamp ts, UUID playerId, String rulesetVersion);
-    CompletableFuture<Void> joinGame(StreamTimestamp ts, UUID playerId, UUID gameId);
+    UUID startGame(StreamTimestamp ts, UUID playerId, String rulesetVersion);
+    void joinGame(StreamTimestamp ts, UUID playerId, UUID gameId);
 
-    CompletableFuture<Void> playTurn(StreamTimestamp ts, UUID playerId, UUID gameId, Card card, Optional<BoardSlot> toSlot);
+    void playTurn(StreamTimestamp ts, UUID playerId, UUID gameId, Card card, Optional<BoardSlot> toSlot);
 
-    CompletableFuture<Void> surrender(StreamTimestamp ts, UUID playerId, UUID gameId);
+    void surrender(StreamTimestamp ts, UUID playerId, UUID gameId);
 }

--- a/concursus-game-demo/src/test/java/com/opencredo/concourse/demo/game/PlayerCommandsTest.java
+++ b/concursus-game-demo/src/test/java/com/opencredo/concourse/demo/game/PlayerCommandsTest.java
@@ -65,20 +65,20 @@ public class PlayerCommandsTest {
     }
 
     @Test
-    public void playAGame() throws ExecutionException, InterruptedException {
-        UUID playerOneId = cmd.create(now(), UUID.randomUUID(), "Player 1").get();
-        UUID playerTwoId = cmd.create(now(), UUID.randomUUID(), "Player 2").get();
+    public void playAGame() {
+        UUID playerOneId = cmd.create(now(), UUID.randomUUID(), "Player 1");
+        UUID playerTwoId = cmd.create(now(), UUID.randomUUID(), "Player 2");
 
-        UUID gameId = cmd.startGame(now(), playerOneId, "0.0.1").get();
+        UUID gameId = cmd.startGame(now(), playerOneId, "0.0.1");
 
-        cmd.joinGame(now(), playerTwoId, gameId).get();
+        cmd.joinGame(now(), playerTwoId, gameId);
 
         gameContinuesAfter(Card.ANGEL_SUMMONER, Card.CHAOS_BADGER);
         victoryAfter(Card.NECROTIC_TOXICITY);
 
-        cmd.playTurn(now(), playerOneId, gameId, Card.ANGEL_SUMMONER, Optional.of(BoardSlot.of(3, BoardRow.PLAYER))).get();
-        cmd.playTurn(now(), playerTwoId, gameId, Card.CHAOS_BADGER, Optional.of(BoardSlot.of(2, BoardRow.PLAYER))).get();
-        cmd.playTurn(now(), playerOneId, gameId, Card.NECROTIC_TOXICITY, Optional.empty()).get();
+        cmd.playTurn(now(), playerOneId, gameId, Card.ANGEL_SUMMONER, Optional.of(BoardSlot.of(3, BoardRow.PLAYER)));
+        cmd.playTurn(now(), playerTwoId, gameId, Card.CHAOS_BADGER, Optional.of(BoardSlot.of(2, BoardRow.PLAYER)));
+        cmd.playTurn(now(), playerOneId, gameId, Card.NECROTIC_TOXICITY, Optional.empty());
 
         PlayerState playerOneState = playerStateRepository.getState(playerOneId).get();
         PlayerState playerTwoState = playerStateRepository.getState(playerTwoId).get();

--- a/concursus-kotlin/src/test/java/com/opencredo/concursus/kotlin/LightbulbEvents.kt
+++ b/concursus-kotlin/src/test/java/com/opencredo/concursus/kotlin/LightbulbEvents.kt
@@ -75,13 +75,13 @@ fun main(args: Array<String>) {
     val lightbulbId = UUID.randomUUID()
     var start = StreamTimestamp.now()
 
-    eventBus.dispatch(LightbulbEvent.Factory, {
+    eventBus.dispatch(LightbulbEvent.Factory) {
         write(start.plus(1, MILLIS), lightbulbId, Created(wattage = 100))
         write(start,                 lightbulbId, ScrewedIn(location = "hallway"))
         write(start.plus(2, MILLIS), lightbulbId, SwitchedOn())
         write(start.plus(1, HOURS),  lightbulbId, SwitchedOff())
         write(start.plus(3, HOURS),  lightbulbId, SwitchedOn())
-    })
+    }
 
     val cached = eventSource.preload(LightbulbEvent::class, arrayListOf(lightbulbId))
 

--- a/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/proxying/CommandExecutionException.java
+++ b/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/proxying/CommandExecutionException.java
@@ -1,0 +1,7 @@
+package com.opencredo.concursus.mapping.commands.methods.proxying;
+
+public class CommandExecutionException extends RuntimeException {
+    public CommandExecutionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/proxying/CommandIssuingProxy.java
+++ b/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/proxying/CommandIssuingProxy.java
@@ -6,14 +6,20 @@ import com.opencredo.concursus.mapping.commands.methods.reflection.CommandInterf
 import com.opencredo.concursus.mapping.commands.methods.reflection.CommandMethodMapping;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * A proxy that converts method invocations into commands
  */
 public final class CommandIssuingProxy implements InvocationHandler {
+
 
     /**
      * Create an CommandIssuingProxy proxying the given interface, and dispatching the issued commands via the supplied {@link CommandOutChannel}.
@@ -23,29 +29,55 @@ public final class CommandIssuingProxy implements InvocationHandler {
      * @return The proxy instance.
      */
     public static <T> T proxying(CommandOutChannel commandOutChannel, Class<T> commandInterface) {
+        return proxying(commandOutChannel, commandInterface, 30000);
+    }
+
+    /**
+     * Create an CommandIssuingProxy proxying the given interface, and dispatching the issued commands via the supplied {@link CommandOutChannel}.
+     * @param commandOutChannel The Consumer that will be called back with commands.
+     * @param commandInterface The interface to proxy.
+     * @param timeoutMs The number of milliseconds to wait before timing out a command.
+     * @param <T> The type of the interface to proxy.
+     * @return The proxy instance.
+     */
+    public static <T> T proxying(CommandOutChannel commandOutChannel, Class<T> commandInterface, long timeoutMs) {
         return commandInterface.cast(Proxy.newProxyInstance(commandInterface.getClassLoader(),
                 new Class<?>[] { commandInterface },
-                new CommandIssuingProxy(commandOutChannel, CommandInterfaceInfo.forInterface(commandInterface).getCommandMappers())
+                new CommandIssuingProxy(commandOutChannel, CommandInterfaceInfo.forInterface(commandInterface).getCommandMappers(), timeoutMs)
         ));
     }
 
     private final CommandOutChannel commandOutChannel;
     private final Map<Method, CommandMethodMapping> commandMappers;
+    private final long timeoutMs;
 
-    private CommandIssuingProxy(CommandOutChannel commandOutChannel, Map<Method, CommandMethodMapping> commandMappers) {
+    private CommandIssuingProxy(CommandOutChannel commandOutChannel, Map<Method, CommandMethodMapping> commandMappers, long timeoutMs) {
         this.commandOutChannel = commandOutChannel;
         this.commandMappers = commandMappers;
+        this.timeoutMs = timeoutMs;
     }
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (method.getDeclaringClass().isAssignableFrom(getClass())) {
-            return method.invoke(this, args);
+            try {
+                return method.invoke(this, args);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
         }
 
         CommandMethodMapping mapper = commandMappers.get(method);
         Preconditions.checkState(mapper != null, "No mapper found for method %s", method);
 
-        return commandOutChannel.apply(mapper.mapArguments(args)).thenApply(result -> result.orElse(null));
+        try {
+            return commandOutChannel.apply(mapper.mapArguments(args))
+                    .thenApply(result -> result.orElse(null))
+                    .get(timeoutMs, MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw new CommandExecutionException(e.getCause());
+        } catch (InterruptedException | TimeoutException e) {
+            throw new CommandExecutionException(e);
+        }
     }
 }

--- a/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/reflection/CommandDispatchers.java
+++ b/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/reflection/CommandDispatchers.java
@@ -40,7 +40,7 @@ public final class CommandDispatchers {
         @Override
         public CompletableFuture<?> apply(Object target, Command command) {
             try {
-                return CompletableFuture.class.cast(method.invoke(target, commandMethodMapping.mapCommand(command)));
+                return CompletableFuture.completedFuture(method.invoke(target, commandMethodMapping.mapCommand(command)));
             } catch (InvocationTargetException e) {
                 return CompletableFutures.failing(e.getCause());
             } catch (IllegalAccessException e) {

--- a/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/reflection/CommandMethodMapping.java
+++ b/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/commands/methods/reflection/CommandMethodMapping.java
@@ -14,7 +14,6 @@ import com.opencredo.concursus.mapping.annotations.Name;
 import com.opencredo.concursus.mapping.reflection.ParameterArgs;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.UUID;
 import java.util.function.IntFunction;
@@ -34,14 +33,12 @@ public final class CommandMethodMapping {
         TupleSchema schema = parameterArgs.getTupleSchema(CommandType.of(aggregateType, commandName).toString());
         TupleKey[] tupleKeys = parameterArgs.getTupleKeys(schema);
 
-        Type returnType = ((ParameterizedType) method.getGenericReturnType()).getActualTypeArguments()[0];
-
         return new CommandMethodMapping(
                 aggregateType,
                 commandName,
                 schema,
                 tupleKeys,
-                returnType);
+                method.getGenericReturnType());
     }
 
     private static VersionedName getCommandName(Method method) {

--- a/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/reflection/MethodSelectors.java
+++ b/concursus-mapping/src/main/java/com/opencredo/concursus/mapping/reflection/MethodSelectors.java
@@ -7,7 +7,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 public final class MethodSelectors {
@@ -26,7 +25,6 @@ public final class MethodSelectors {
     }
 
     private static final Predicate<Method> returnsVoid = returnsType(void.class);
-    private static final Predicate<Method> returnsCompletableFuture = returnsType(CompletableFuture.class);
 
     private static final Predicate<Method> isStatic = method -> Modifier.isStatic(method.getModifiers());
 
@@ -63,6 +61,6 @@ public final class MethodSelectors {
     public static final Predicate<Method> isUpdateMethod = handlesEvent.and(isInstance).and(returnsVoid);
 
     public static final Predicate<Method> isCommandIssuingMethod =
-            returnsCompletableFuture.and(isInstance).and(hasTimestampAndUUIDParameters);
+            isInstance.and(hasTimestampAndUUIDParameters);
 
 }


### PR DESCRIPTION
Making the Command Interface methods return CompletableFuture<T> is cumbersome, confusing and could lead people into doing the Wrong Thing in command processors. It's simpler and less confusing to make the methods synchronous, and just have the caller block on command completion.