### PR TITLE
Fix long overflow by specifying getting state upto Instant.now()

### DIFF
--- a/concursus-domain/src/main/java/com/opencredo/concursus/domain/events/state/StateRepository.java
+++ b/concursus-domain/src/main/java/com/opencredo/concursus/domain/events/state/StateRepository.java
@@ -23,7 +23,7 @@ public interface StateRepository<T> {
      * @return The state of the aggregate, if it exists.
      */
     default Optional<T> getState(String aggregateId) {
-        return getState(aggregateId, Instant.MAX);
+        return getState(aggregateId, Instant.now());
     }
 
     /**
@@ -42,7 +42,7 @@ public interface StateRepository<T> {
      * @return The aggregates' states, mapped by aggregate id.
      */
     default Map<String, T> getStates(Collection<String> aggregateIds) {
-        return getStates(aggregateIds, Instant.MAX);
+        return getStates(aggregateIds, Instant.now());
     }
 
     /**


### PR DESCRIPTION
I found this few weeks back when I was doing something similar to the `concursus-spring-boot-demo` app. Then I saw someone has the same problem as reported in issue https://github.com/opencredo/concursus/issues/17

The problem is quite straightforward, when we call `groupStateRepository.getStates(groups)` in test code, it in turn calls `getState(groups, Instant.MAX)`, where `Instant.MAX` is the upper bound. Later on when in `CassandraEventRetriever.constrainBound`, it calls `bound.getInstant().toEpochMilli())` which results in the long overflow exception. 
The problem can be simply reproduced by ` Instant.MAX.toEpochMilli()) `

Anyways, I'm not sure if `Instant.MAX` is intended. From the code comments, it seems to be `Instant.now()`, which translates to _"get the events up to now"_. whereas `Instant.MAX` means to the far future based on its own documentation. 

At the meantime, a simple workaround (as currently what i'm doing) is to specify the upper bound (i.e. do `groupStateRepository.getStates(groups, Instant.now())` instead). The error goes away